### PR TITLE
Fix logo positioning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-<img align="right" width="25%" src="logo.png">
-
 # wgpu
+<img align="right" width="20%" src="logo.png">
 
 [![Matrix Space](https://img.shields.io/static/v1?label=Space&message=%23Wgpu&color=blue&logo=matrix)](https://matrix.to/#/#Wgpu:matrix.org)
 [![Dev Matrix  ](https://img.shields.io/static/v1?label=devs&message=%23wgpu&color=blueviolet&logo=matrix)](https://matrix.to/#/#wgpu:matrix.org)


### PR DESCRIPTION
This is a simple PR that fixes the positioning of the wgpu logo in the README.md